### PR TITLE
Corrige pantalla de confirmación de Comité

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby RUBY_VERSION
 
 gem "decidim", "0.10.1"
 gem "decidim-initiatives", git: "https://github.com/decidim/decidim-initiatives", branch: "master"
-gem "decidim-denuncias", git: "https://github.com/TEDICpy/decidim-reclamos", branch: "development"
+gem "decidim-denuncias", git: "https://github.com/TEDICpy/decidim-reportes", branch: "development"
 gem "decidim-rendezvouses", git: "https://github.com/TEDICpy/decidim-eventos", branch: "development"
 
 gem "puma", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
       decidim-core (= 0.10.1)
 
 GIT
-  remote: https://github.com/TEDICpy/decidim-reclamos
+  remote: https://github.com/TEDICpy/decidim-reportes
   revision: d8507b24169c36b5fb811f903a6eba55134f34ef
   branch: development
   specs:
@@ -87,7 +87,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (8.5.2)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -294,10 +294,10 @@ GEM
     equalizer (0.0.11)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_bot (4.8.2)
+    factory_bot (4.10.0)
       activesupport (>= 3.0.0)
-    factory_bot_rails (4.8.2)
-      factory_bot (~> 4.8.2)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
@@ -317,7 +317,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.4.8)
+    geocoder (1.4.9)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.10)
@@ -592,7 +592,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.10)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.2)
+    unicode-display_width (1.3.3)
     url (0.3.2)
     valid_email2 (2.2.3)
       activemodel (>= 3.2)
@@ -620,7 +620,7 @@ GEM
       railties (>= 3.0.7)
     wisper (2.0.0)
     wisper-rspec (1.1.0)
-    xpath (3.0.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
 
 PLATFORMS

--- a/app/views/decidim/initiatives/committee_requests/new.html.erb
+++ b/app/views/decidim/initiatives/committee_requests/new.html.erb
@@ -1,0 +1,39 @@
+<div class="wrapper">
+  <% add_decidim_meta_tags({
+                               image_url: current_initiative.type.banner_image.url,
+                               description: translated_attribute(current_initiative.description),
+                               title: translated_attribute(current_initiative.title),
+                               url: initiative_url(current_initiative.id),
+                               twitter_handler: current_organization.twitter_handler
+                           }) %>
+
+  <% add_decidim_page_title(translated_attribute(current_initiative.title)) %>
+  <% provide :meta_image_url, current_initiative.type.banner_image.url %>
+
+  <br><br>
+  <div class="row column">
+    <h2 class="heading2"><%= translated_attribute(current_initiative.title) %></h2>
+    <%= render partial: "decidim/initiatives/initiatives/author", locals: {initiative: current_initiative} %>
+  </div>
+
+  <div class="row">
+    <div class="columns large-12">
+      <div class="section">
+        <%= sanitize translated_attribute(current_initiative.description) %>
+      </div>
+
+      <div class="section">
+        <p><%= t ".help_text" %></p>
+        <%= link_to t(".continue"),
+                    spawn_initiative_committee_requests_path(current_initiative),
+                    class: "title-action__action button small hollow" if current_user %>
+
+        <%= action_authorized_link_to :spawn,
+                                      t(".continue"),
+                                      spawn_initiative_committee_requests_path(current_initiative),
+                                      class: "title-action__action button small hollow" unless current_user %>
+      </div>
+    </div>
+  </div>
+</div>
+<%= stylesheet_link_tag "decidim/initiatives/application" %>


### PR DESCRIPTION
- Se corrige el error reportado en #27, ahora el mensaje de confirmación de creación de comité se ve correctamente.
- Se actualiza la referencia al proyecto de `reportes`