### PR TITLE
Errores de internacionalización

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "decidim", "0.10.1"
-gem "decidim-initiatives", git: "https://github.com/decidim/decidim-initiatives", branch: "master"
+gem "decidim-initiatives", git: "https://github.com/diegocrzt/decidim-initiatives", branch: "development"
 gem "decidim-denuncias", git: "https://github.com/TEDICpy/decidim-reportes", branch: "development"
 gem "decidim-rendezvouses", git: "https://github.com/TEDICpy/decidim-eventos", branch: "development"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GIT
       wicked
 
 GIT
-  remote: https://github.com/decidim/decidim-initiatives
-  revision: 276cb0882ded66eafad991b2aefbbe3859e13e9a
-  branch: master
+  remote: https://github.com/diegocrzt/decidim-initiatives
+  revision: 6726324533d6c52e0d98528df8625f38c161cbad
+  branch: development
   specs:
     decidim-initiatives (0.10.0.pre)
       decidim-admin

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -22,10 +22,10 @@ es:
         home:
           highlighted_processes:
             active_processes: Activos ahora
-    cookie_warning:
-      description_html: FIXME: mensaje genial sobre las cookies con el %{link} de terminos y condiciones.
-
-
+  layouts:
+    decidim:
+      cookie_warning:
+        description_html: "FIXME: mensaje genial sobre las cookies con el %{link} de terminos y condiciones."
   pages:
       home:
         extended:


### PR DESCRIPTION
- Corrige errores de internacionalización debido a claves faltantes en los módulos de reportes e iniciativas (#25)
- Agregando la clave de internacionalización adecuada se actualiza el texto que muestra el mensaje sobre uso de cookies a un valor de prueba, como se sugiere en #22 