### PR TITLE
Elimina el comité de los reportes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/TEDICpy/decidim-reportes
-  revision: 8fec02700a4ed01e7de4c8d1e9770a4cd4e72ad2
+  revision: 2ecf62440557778afe54398a448731f11f70f173
   branch: development
   specs:
     decidim-denuncias (0.10.1)
@@ -87,7 +87,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
-    autoprefixer-rails (8.5.2)
+    autoprefixer-rails (8.6.0)
       execjs
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -303,7 +303,7 @@ GEM
       i18n (>= 0.7)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     file_validators (2.3.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
@@ -590,7 +590,7 @@ GEM
       nokogiri (~> 1.8.0, >= 1.7.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.10)
+    uglifier (4.1.11)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.3)
     url (0.3.2)


### PR DESCRIPTION
Simplifica el flujo de creación de reportes eliminando la necesidad de crear un comité de tres personas que aprueben el reporte