### PR TITLE
Corrige url de mapa estático

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -13,9 +13,7 @@ Decidim.configure do |config|
 
   # Geocoder configuration
   config.geocoder = {
-     #static_map_url: "https://image.maps.cit.api.here.com/mia/1.6/mapview",
-     #static_map_url: "https://maps.wikimedia.org/osm-intl", #/${z}/${x}/${y}.png
-     static_map_url: "https://tile.openstreetmap.org", #/${z}/${x}/${y}.png
+     static_map_url: "https://image.maps.cit.api.here.com/mia/1.6/mapview",
      here_app_id: Rails.application.secrets.geocoder[:here_app_id],
      here_app_code: Rails.application.secrets.geocoder[:here_app_code]
   }


### PR DESCRIPTION
- El mapa estático de encuentros es independiente ahora al mapa estático
de eventos.

refs: DI #5 
https://github.com/TEDICpy/decidim-reportes/issues/7
https://github.com/TEDICpy/decidim-initiatives/issues/5

Signed-off-by: Diego Ramírez <diegocrzt@gmail.com>