### PR TITLE
Muestra el conteo de eventos en portada

### DIFF
--- a/app/presenters/decidim/home_stats_presenter.rb
+++ b/app/presenters/decidim/home_stats_presenter.rb
@@ -4,12 +4,14 @@ module Decidim
   # A presenter to render statistics in the homepage.
   class HomeStatsPresenter < Rectify::Presenter
     attribute :organization, Decidim::Organization
+    include Decidim::ViewHooksHelper
 
     # Public: Render a collection of primary stats.
     def highlighted
       highlighted_stats = Decidim.stats.only([:users_count, :processes_count]).with_context(organization).map {|name, data| [name, data]}
       highlighted_stats = highlighted_stats.concat(published_initiatives)
       highlighted_stats = highlighted_stats.concat(published_denuncias)
+      highlighted_stats = highlighted_stats.concat(rendezvouses_count)
       highlighted_stats = highlighted_stats.concat(global_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.concat(feature_stats(priority: StatsRegistry::HIGH_PRIORITY))
       highlighted_stats = highlighted_stats.reject(&:empty?)
@@ -97,6 +99,11 @@ module Decidim
     def published_denuncias
       k = Decidim::Denuncia.where(organization: organization).published.count
       [[:denuncias_count, k]]
+    end
+
+    def rendezvouses_count
+      k = rendezvouses.count
+      [[:eventos_count, k]]
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,3 +54,4 @@ en:
         statistics:
           initiatives_count: Initiatives
           denuncias_count: Claims
+          eventos_count: Events

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -35,3 +35,4 @@ es:
         statistics:
           initiatives_count: Iniciativas
           denuncias_count: Reportes
+          eventos_count: Eventos

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,24 @@
+# Tareas programadas
+
+Se provee el script `cronjob.sh` como ejemplo de ejecución de las tareas necesarias para el módulo de iniciativas
+
+
+## Configurar la tarea
+
+- Usando la cuenta de usuario que tiene permisos para ejecutar la aplicación (ejemplo `www-data`) 
+
+- Editar una tarea cron
+
+`crontab -e `
+
+- Configurar la tarea para ejecutarse todos los días a las 00:00
+
+```cron
+0 0 * * * sh /var/www/html/util/cronjob.sh /var/www/html
+```
+
+OBS: 
+
+`/var/www/html/util/cronjob.sh` es una ubicación de ejemplo del script
+
+`/var/www/html` es un ejemplo de ubicación de la aplicación

--- a/util/cronjob.sh
+++ b/util/cronjob.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+APP_DIR=${1};
+LOG_FILE="/tmp/miciudad_cronjob";
+if [ -z  ${APP_DIR} ] ; 
+then
+	echo "${APP_DIR} no es un directorio válido" >> ${LOG_FILE};
+	exit -1;
+fi
+
+cd ${APP_DIR};
+
+bin/rails decidim_initiatives:check_published >> ${LOG_FILE} 2>&1;
+bin/rails decidim_initiatives:check_validating >> ${LOG_FILE} 2>&1;
+bin/rails decidim_initiatives:notify_progress >> ${LOG_FILE} 2>&1;
+
+echo "Ejecución completa" >> ${LOG_FILE};


### PR DESCRIPTION
- Muestra el conteo de eventos próximos en la portada.
- Agrega un ejemplo de cronjob para ciertas tareas programadas

refs: MC #40

Signed-off-by: Diego Ramírez <diegocrzt@gmail.com>