### PR TITLE
Fuerza uso de localización paraguaya

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -27,7 +27,8 @@ Decidim.configure do |config|
   # end
 
   # Currency unit
-  # config.currency_unit = "€"
+  config.currency_unit = "₲"
+  config.time_zone = "America/Asuncion"
 
   # The number of reports which an object can receive before hiding it
   # config.max_reports_before_hiding = 3


### PR DESCRIPTION
- Moneda en ₲
- America/Asuncion como timezone

refs: #42

Signed-off-by: Diego Ramírez <diegocrzt@gmail.com>