### PR TITLE
Conteo de eventos incluye eventos pasados

### DIFF
--- a/app/helpers/decidim/view_hooks_helper.rb
+++ b/app/helpers/decidim/view_hooks_helper.rb
@@ -24,9 +24,18 @@ module Decidim
       next_rendezvouses(deep_dup)
     end
 
+    def rendezvouses_all
+      all_rendezvouses(deep_dup)
+    end
+
     def next_rendezvouses(view_context)
       search = Decidim::Rendezvouses::RendezvousSearch.new({:date => "upcoming"})
-      next_rendezvouses = search.results
+      search.results
+    end
+
+    def all_rendezvouses(view_context)
+      search = Decidim::Rendezvouses::RendezvousSearch.new({})
+      search.results
     end
 
     def render_initiatives(view_context)

--- a/app/presenters/decidim/home_stats_presenter.rb
+++ b/app/presenters/decidim/home_stats_presenter.rb
@@ -102,7 +102,7 @@ module Decidim
     end
 
     def rendezvouses_count
-      k = rendezvouses.count
+      k = rendezvouses_all.count
       [[:eventos_count, k]]
     end
   end

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -11,6 +11,10 @@ es:
       automatic_authorization_handler:
               name: Autorización automática
               explanation: Verifica tu identidad automáticamente
+    devise:
+      registrations:
+        new:
+          newsletter: Quiero recibir un boletín ocasional con información relevante.
     verifications:
       authorizations:
         first_login:


### PR DESCRIPTION
Según se discutió en MC #40, se muestra el conteo de eventos considerando los eventos pasados ademas de los próximos. Pero el listado de eventos destacados solo muestra los eventos próximos, siguiendo el comportamiento de los otros componentes como iniciativas o reportes.

### Conteo de eventos.

![20180713111028_m4800](https://user-images.githubusercontent.com/6553005/42698973-6e84fe74-868d-11e8-9efe-91ef2bbf09d8.png)

### Evento destacado 

![20180713111018_m4800](https://user-images.githubusercontent.com/6553005/42699003-8c4622d0-868d-11e8-8ff0-990ea2c51814.png)

### Listado deventos pŕoximos/pasados

![20180713111038_m4800](https://user-images.githubusercontent.com/6553005/42699018-97727618-868d-11e8-887f-3a2ac7b2fc61.png)

![20180713111048_m4800](https://user-images.githubusercontent.com/6553005/42699025-99ee2450-868d-11e8-99e6-88a8262b881c.png)


