### PR TITLE
Agrega soporte a georeferencias en reportes

### DIFF
--- a/db/migrate/20180713210858_add_latitude_longitude_to_denuncia.decidim_denuncias.rb
+++ b/db/migrate/20180713210858_add_latitude_longitude_to_denuncia.decidim_denuncias.rb
@@ -1,0 +1,7 @@
+# This migration comes from decidim_denuncias (originally 20180713210735)
+class AddLatitudeLongitudeToDenuncia < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_denuncias, :latitude, :float
+    add_column :decidim_denuncias, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606231014) do
+ActiveRecord::Schema.define(version: 20180713210858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,8 @@ ActiveRecord::Schema.define(version: 20180606231014) do
     t.datetime "first_progress_notification_at"
     t.datetime "second_progress_notification_at"
     t.integer "offline_votes"
+    t.float "latitude"
+    t.float "longitude"
     t.index "md5((description)::text)", name: "decidim_denuncias_description_search"
     t.index ["answered_at"], name: "index_decidim_denuncias_on_answered_at"
     t.index ["decidim_author_id"], name: "index_decidim_denuncias_on_decidim_author_id"
@@ -412,7 +414,6 @@ ActiveRecord::Schema.define(version: 20180606231014) do
     t.datetime "first_progress_notification_at"
     t.datetime "second_progress_notification_at"
     t.integer "offline_votes"
-    t.string "image2"
     t.string "image"
     t.index "md5((description)::text)", name: "decidim_initiatives_description_search"
     t.index ["answered_at"], name: "index_decidim_initiatives_on_answered_at"


### PR DESCRIPTION
- Agrega soporte para georeferencias (lat/long) en las tablas de
reportes.

Refs: https://github.com/TEDICpy/decidim-reportes/issues/13
Signed-off-by: Diego Ramírez <diegocrzt@gmail.com>